### PR TITLE
Fix issues with Xcode 7.3

### DIFF
--- a/CrashSymbal/Info.plist
+++ b/CrashSymbal/Info.plist
@@ -32,6 +32,7 @@
 		<string>7FDF5C7A-131F-4ABB-9EDC-8C5F8F0B8A90</string>
 		<string>7265231C-39B4-402C-89E1-16167C4CC990</string>
 		<string>F41BD31E-2683-44B8-AE7F-5F09E919790E</string>
+		<string>ACA8656B-FEA8-4B6D-8E4A-93F4C95C362C</string>
 	</array>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>

--- a/CrashSymbal/JFWSymbolicateViewController.m
+++ b/CrashSymbal/JFWSymbolicateViewController.m
@@ -179,6 +179,21 @@
 			NSString *developerDir = [[[NSBundle mainBundle] bundlePath] stringByAppendingPathComponent:@"Contents/Developer"];
 			
 			NSTask *symbolicationTask = [[NSTask alloc] init];
+						NSString *symbolicatecrashPath = [[NSBundle bundleWithIdentifier:@"com.apple.dt.DVTFoundation"] pathForResource:@"symbolicatecrash" ofType:nil];
+
+			if (symbolicatecrashPath == nil) {
+				// Try an older style bundle identifier
+				symbolicatecrashPath = [[NSBundle bundleWithIdentifier:@"com.apple.DTDeviceKitBase"] pathForResource:@"symbolicatecrash" ofType:nil];
+			}
+
+			if (symbolicatecrashPath == nil) {
+				NSLog(@"CrashSymbal: cannot locate 'symbolicatecrash' in this version of Xcode");
+
+				return;
+			}
+
+			NSLog(@"CrashSymbal:symbolicatecrash: %@", symbolicatecrashPath);
+
 			[symbolicationTask setLaunchPath:[[NSBundle bundleWithIdentifier:@"com.apple.DTDeviceKitBase"] pathForResource:@"symbolicatecrash" ofType:nil]];
 			[symbolicationTask setEnvironment:@{@"DEVELOPER_DIR": developerDir}];
 			[symbolicationTask setArguments:@[@"-v", [self selectedPath]]];


### PR DESCRIPTION
1. Add Xcode 7.3 UUID
2. Fix problem finding the 'symbolicatecrash' utility introduced by Xcode 7.3
